### PR TITLE
[EIP-1898] add a possibility to pass blockHash for eth_call method

### DIFF
--- a/lib/servers/database.d.ts
+++ b/lib/servers/database.d.ts
@@ -7,7 +7,7 @@ export declare class DatabaseServer extends SkeletonServer {
     protected _init(): Promise<void>;
     protected _query(query: string | sql.SelectStatement, args?: unknown[]): Promise<pg.QueryResult<any>>;
     eth_blockNumber(): Promise<web3.Quantity>;
-    eth_call(transaction: web3.TransactionForCall, blockNumber?: web3.Quantity | web3.Tag): Promise<web3.Data>;
+    eth_call(transaction: web3.TransactionForCall, blockNumberOrHash?: web3.Quantity | web3.Tag | web3.Data): Promise<web3.Data>;
     eth_chainId(): Promise<web3.Quantity>;
     eth_coinbase(): Promise<web3.Data>;
     eth_getBalance(address: web3.Data, blockNumber?: web3.Quantity | web3.Tag): Promise<web3.Quantity>;

--- a/lib/servers/database.js
+++ b/lib/servers/database.js
@@ -54,8 +54,19 @@ export class DatabaseServer extends SkeletonServer {
     async eth_blockNumber() {
         return intToHex(await this._fetchCurrentBlockID());
     }
-    async eth_call(transaction, blockNumber) {
-        const blockNumber_ = parseBlockSpec(blockNumber);
+    async eth_call(transaction, blockNumberOrHash) {
+        let blockNumber_;
+        // EIP-1898 (enables the argument to be not only blockNumber, but also blockHash)
+        if (blockNumberOrHash?.startsWith('0x')) {
+            const block_ = await (this.eth_getBlockByHash(blockNumberOrHash));
+            if (block_ === null) {
+                throw new InvalidArguments();
+            }
+            blockNumber_ = parseBlockSpec(block_['number']?.toString());
+        }
+        if (!blockNumberOrHash?.startsWith('0x')) {
+            blockNumber_ = parseBlockSpec(blockNumberOrHash);
+        }
         const from = transaction.from
             ? parseAddress(transaction.from)
             : Address.zero();

--- a/src/servers/database.ts
+++ b/src/servers/database.ts
@@ -94,9 +94,14 @@ export class DatabaseServer extends SkeletonServer {
 
   async eth_call(
     transaction: web3.TransactionForCall,
-    blockNumber?: web3.Quantity | web3.Tag
+    blockNumber?: web3.Quantity | web3.Tag,
+    blockHash?: web3.Data
   ): Promise<web3.Data> {
-    const blockNumber_ = parseBlockSpec(blockNumber);
+    let blockNumber_ = parseBlockSpec(blockNumber);
+    if (blockHash !== undefined && blockNumber_ === undefined) {
+        const block_ = await(this.eth_getBlockByHash(blockHash))
+        blockNumber_ = block_ ? parseBlockSpec(block_['number']?.toString()) : null;
+    }
     const from = transaction.from
       ? parseAddress(transaction.from)
       : Address.zero();


### PR DESCRIPTION
The Graph needs the https://eips.ethereum.org/EIPS/eip-1898 support.
From the list of methods they've requested, only `eth_call` correlates with the EIP above.
As a result, I've added a possibility to pass the `blockHash` as a parameter to the call, before only `blockNumber` was supported.