### PR TITLE
Fix/eth_call

### DIFF
--- a/lib/servers/database.js
+++ b/lib/servers/database.js
@@ -57,15 +57,15 @@ export class DatabaseServer extends SkeletonServer {
     async eth_call(transaction, blockNumberOrHash) {
         let blockNumber_;
         // EIP-1898 (enables the argument to be not only blockNumber, but also blockHash)
-        if (blockNumberOrHash?.startsWith('0x')) {
-            const block_ = await (this.eth_getBlockByHash(blockNumberOrHash));
-            if (block_ === null) {
-                throw new InvalidArguments();
+        if (typeof blockNumberOrHash === 'string') {
+            if (/^0x([A-Fa-f0-9]{64})$/.test(blockNumberOrHash)) {
+                // Regex reference here https://ethereum.stackexchange.com/questions/34285/what-is-the-regex-to-validate-an-ethereum-transaction-hash/34286#34286
+                const block_ = await this.eth_getBlockByHash(blockNumberOrHash);
+                blockNumber_ = parseBlockSpec(block_ ? block_['number']?.toString() : null);
             }
-            blockNumber_ = parseBlockSpec(block_['number']?.toString());
-        }
-        if (!blockNumberOrHash?.startsWith('0x')) {
-            blockNumber_ = parseBlockSpec(blockNumberOrHash);
+            else {
+                blockNumber_ = parseBlockSpec(blockNumberOrHash);
+            }
         }
         const from = transaction.from
             ? parseAddress(transaction.from)

--- a/src/servers/database.ts
+++ b/src/servers/database.ts
@@ -98,13 +98,15 @@ export class DatabaseServer extends SkeletonServer {
   ): Promise<web3.Data> {
     let blockNumber_
     // EIP-1898 (enables the argument to be not only blockNumber, but also blockHash)
-    if (blockNumberOrHash?.startsWith('0x')) {
-      const block_ = await(this.eth_getBlockByHash(blockNumberOrHash))
-      if (block_ === null) { throw new InvalidArguments(); }
-      blockNumber_ = parseBlockSpec(block_['number']?.toString());
-    }
-    if (!blockNumberOrHash?.startsWith('0x')) {
-      blockNumber_ = parseBlockSpec(blockNumberOrHash);
+    if(typeof blockNumberOrHash === 'string'){
+      if (/^0x([A-Fa-f0-9]{64})$/.test(blockNumberOrHash)) {
+        // Regex reference here https://ethereum.stackexchange.com/questions/34285/what-is-the-regex-to-validate-an-ethereum-transaction-hash/34286#34286
+        const block_ = await this.eth_getBlockByHash(blockNumberOrHash);
+        blockNumber_ = parseBlockSpec(block_? block_['number']?.toString(): null);
+      }
+      else {
+        blockNumber_ = parseBlockSpec(blockNumberOrHash);
+      }
     }
     const from = transaction.from
       ? parseAddress(transaction.from)


### PR DESCRIPTION
I've tested the `eth_call` RPC method using the `blockHash`, `blockNumber` and MetaMask.

```
ahmedali@Ahmeds-MBP aurora.js % http post $ENDPOINT jsonrpc=2.0 id=1 method=eth_call params:='[{"from":"0x6a33382de9f73b846878a57500d055b981229ac4","to":"0x18dc9e580fc0799ee488145f20c6dae8ffd0a812","data":"0x70a082310000000000000000000000006a33382de9f73b846878a57500d055b981229ac4"},"0x2668bb98176feff9cadd5c2327d39de7df59f5793aca0b7c9878945a00372019"]'
HTTP/1.1 200 OK
Access-Control-Allow-Origin: *
Connection: keep-alive
Content-Length: 104
Content-Type: application/json; charset=utf-8
Date: Mon, 13 Sep 2021 11:39:18 GMT
Keep-Alive: timeout=5
X-Request-ID: CbLqGN6W8KnWMGK6

{
    "id": "1",
    "jsonrpc": "2.0",
    "result": "0x00000000000000000000000000000000000000000000000000000000000f4240"
}


ahmedali@Ahmeds-MBP aurora.js % http post $ENDPOINT jsonrpc=2.0 id=1 method=eth_call params:='[{"from":"0x6a33382de9f73b846878a57500d055b981229ac4","to":"0x18dc9e580fc0799ee488145f20c6dae8ffd0a812","data":"0x70a082310000000000000000000000006a33382de9f73b846878a57500d055b981229ac4"},"63035813"]'                                                          
HTTP/1.1 200 OK
Access-Control-Allow-Origin: *
Connection: keep-alive
Content-Length: 104
Content-Type: application/json; charset=utf-8
Date: Mon, 13 Sep 2021 11:39:37 GMT
Keep-Alive: timeout=5
X-Request-ID: 9bhRQMrF6cwKwBtT

{
    "id": "1",
    "jsonrpc": "2.0",
    "result": "0x00000000000000000000000000000000000000000000000000000000000f4240"
}


ahmedali@Ahmeds-MBP aurora.js % 
```

![image](https://user-images.githubusercontent.com/5428661/133078070-4b8428b9-7805-4874-93cf-11c895d3ed25.png)
