### PR TITLE
Add CI-environment setup for RPC-tests

### DIFF
--- a/.ci/.gitignore
+++ b/.ci/.gitignore
@@ -1,0 +1,1 @@
+workdir/

--- a/.ci/README.md
+++ b/.ci/README.md
@@ -1,2 +1,22 @@
 Those scripts are for CI only.
 Please don't try to run them on your local machine.
+
+Setup does the following:
+1. Build docker images for `database` and `endpoint`
+2. Pull, init and run `nearcore`
+3. Create account `aurora.test.near`
+4. Install `aurora-engine` contract
+5. Run `database`, `indexer` and `endpoint`
+
+All containers are connected to Docker bridge-network, so Docker's dynamic service-discovery is used to allow containers access each other (`hostname` = `container name`).
+
+**Important**:
+Dependency versions are locked for CI consistency (nearcore, aurora-cli, near-cli, aurora-engine).
+Perform manual edit on `.ci/common.sh` to update versions.
+
+Each test-workflow should follow the same template:
+1. Call `./.ci/setup.sh`
+2. Get endpoint hostname from `./.ci/workdir/endpoint.txt`
+3. Run tests
+4. Print logs (if needed) by calling `./.ci/show_logs.sh [nearcore | database | indexer | endpoint]`
+5. Always call `./.ci/cleanup.sh`

--- a/.ci/README.md
+++ b/.ci/README.md
@@ -1,0 +1,2 @@
+Those scripts are for CI only.
+Please don't try to run them on your local machine.

--- a/.ci/cleanup.sh
+++ b/.ci/cleanup.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -ev
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-source SCRIPT_DIR/common.sh
-cd SCRIPT_DIR/..
+source $SCRIPT_DIR/common.sh
+cd $SCRIPT_DIR/..
 
 
 echo "Cleaning docker objects..."

--- a/.ci/cleanup.sh
+++ b/.ci/cleanup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source $SCRIPT_DIR/common.sh
@@ -6,28 +6,30 @@ cd $SCRIPT_DIR/..
 
 
 echo "Cleaning docker objects..."
+{
+    docker stop \
+        $ENDPOINT_CONTAINER_NAME \
+        $INDEXER_CONTAINER_NAME \
+        $DATABASE_CONTAINER_NAME \
+        $NEARCORE_CONTAINER_NAME \
+        || true
 
-docker stop \
-    $ENDPOINT_CONTAINER_NAME \
-    $INDEXER_CONTAINER_NAME \
-    $DATABASE_CONTAINER_NAME \
-    $NEARCORE_CONTAINER_NAME \
-    || true
+    docker rm -f \
+        $ENDPOINT_CONTAINER_NAME \
+        $INDEXER_CONTAINER_NAME \
+        $DATABASE_CONTAINER_NAME \
+        $NEARCORE_CONTAINER_NAME \
+        || true
 
-docker rm -f \
-    $ENDPOINT_CONTAINER_NAME \
-    $INDEXER_CONTAINER_NAME \
-    $DATABASE_CONTAINER_NAME \
-    $NEARCORE_CONTAINER_NAME \
-    || true
+    docker rmi -f \
+        $ENDPOINT_IMAGE_NAME \
+        $DATABASE_IMAGE_NAME \
+        || true
 
-docker rmi -f \
-    $ENDPOINT_IMAGE_NAME \
-    $DATABASE_IMAGE_NAME \
-    || true
+    docker network disconnect -f $NETWORK_NAME $RUNNER_NAME || true
+    docker network rm $NETWORK_NAME || true
 
-docker network disconnect -f $NETWORK_NAME $RUNNER_NAME || true
-docker network rm $NETWORK_NAME || true
+} &> /dev/null
 
 
 echo "Cleaning files..."

--- a/.ci/cleanup.sh
+++ b/.ci/cleanup.sh
@@ -1,0 +1,41 @@
+#!/bin/bash -ev
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source SCRIPT_DIR/common.sh
+cd SCRIPT_DIR/..
+
+
+echo "Cleaning docker objects..."
+
+docker stop \
+    $ENDPOINT_CONTAINER_NAME \
+    $INDEXER_CONTAINER_NAME \
+    $DATABASE_CONTAINER_NAME \
+    $NEARCORE_CONTAINER_NAME \
+    || true
+
+docker rm -f \
+    $ENDPOINT_CONTAINER_NAME \
+    $INDEXER_CONTAINER_NAME \
+    $DATABASE_CONTAINER_NAME \
+    $NEARCORE_CONTAINER_NAME \
+    || true
+
+docker rmi -f \
+    $ENDPOINT_IMAGE_NAME \
+    $DATABASE_IMAGE_NAME \
+    || true
+
+docker network disconnect -f $NETWORK_NAME $RUNNER_NAME || true
+docker network rm $NETWORK_NAME || true
+
+
+echo "Cleaning files..."
+rm -rf \
+    .ci/workdir \
+    ~/.near-credentials \
+    config/local.yaml \
+    config/aurora.test.near.json
+
+
+echo "Cleanup finished!"

--- a/.ci/cleanup.sh
+++ b/.ci/cleanup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ev
+#!/bin/bash -ex
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source $SCRIPT_DIR/common.sh

--- a/.ci/common.sh
+++ b/.ci/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ev
+#!/bin/bash -ex
 
 
 # All CI-runners are docker containers, and creating new
@@ -9,7 +9,7 @@
 # To avoid collision of such objects, $RUNNER_NAME suffix
 # is added to every object's name.
 
-UNIQUE_KEY=$RUNNER_NAME
+UNIQUE_KEY=$(echo $RUNNER_NAME | tr '[:upper:]' '[:lower:]')
 
 NETWORK_NAME=network-for-$UNIQUE_KEY
 DATABASE_IMAGE_NAME=relayer-database-img-$UNIQUE_KEY

--- a/.ci/common.sh
+++ b/.ci/common.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -ev
+
+
+# All CI-runners are docker containers, and creating new
+# Docker objects (images, containers, etc) from some runner
+# will make them appear on host-level Docker, since
+# socket-binding solution is used for Docker-in-Docker. 
+#
+# To avoid collision of such objects, $RUNNER_NAME suffix
+# is added to every object's name.
+
+UNIQUE_KEY=$RUNNER_NAME
+
+NETWORK_NAME=network-for-$UNIQUE_KEY
+DATABASE_IMAGE_NAME=relayer-database-img-$UNIQUE_KEY
+ENDPOINT_IMAGE_NAME=relayer-endpoint-img-$UNIQUE_KEY
+DATABASE_CONTAINER_NAME=relayer-database-$UNIQUE_KEY
+INDEXER_CONTAINER_NAME=relayer-indexer-$UNIQUE_KEY
+ENDPOINT_CONTAINER_NAME=relayer-endpoint-$UNIQUE_KEY
+NEARCORE_CONTAINER_NAME=nearcore-$UNIQUE_KEY
+
+
+# Version locks.
+# Specific versions of each dependency are used
+# in order to provide consistent CI.
+
+NEAR_CLI_HEAD=e7a2c8fcd428b6ae006dcf5340b1469d9ec815b0
+# Commit hash from: https://github.com/near/near-cli/commits/master
+
+AURORA_CLI_HEAD=7f7c2d29c5114db2b6530a6c0fa09b2068f217df
+# Commit hash from: https://github.com/aurora-is-near/aurora-cli/commits/master
+
+NEARCORE_TAG=master-8a2be9ce7768fc4b58558ad73dacfc794b5bef4f
+# Docker image tag from: https://hub.docker.com/r/nearprotocol/nearcore/tags
+
+CONTRACT_URL=https://github.com/aurora-is-near/aurora-engine/releases/download/1.6.4/mainnet-release.wasm
+# Download url from: https://github.com/aurora-is-near/aurora-engine/releases

--- a/.ci/common.sh
+++ b/.ci/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 
 # All CI-runners are docker containers, and creating new

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -109,7 +109,7 @@ docker run -d --rm --init \
     --network $NETWORK_NAME \
     -e NEAR_ENV=localnet \
     -e NODE_ENV=localnet \
-    -v ./config:/srv/aurora/relayer/config \
+    -v $(pwd)/config:/srv/aurora/relayer/config \
     --name $INDEXER_CONTAINER_NAME \
     $ENDPOINT_IMAGE_NAME \
     node lib/indexer.js
@@ -119,7 +119,7 @@ docker run -d --rm --init \
     --network $NETWORK_NAME \
     -e NEAR_ENV=localnet \
     -e NODE_ENV=localnet \
-    -v ./config:/srv/aurora/relayer/config \
+    -v $(pwd)/config:/srv/aurora/relayer/config \
     --name $ENDPOINT_CONTAINER_NAME \
     $ENDPOINT_IMAGE_NAME \
     node lib/index.js

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -49,7 +49,8 @@ docker run --rm \
     --name $NEARCORE_CONTAINER_NAME \
     nearprotocol/nearcore:$NEARCORE_TAG \
     neard --home=/srv/near init
-docker run -d --rm \
+docker run -d \
+    --restart unless-stopped \
     -v $(pwd)/.ci/workdir/nearData:/srv/near \
     --network $NETWORK_NAME \
     --name $NEARCORE_CONTAINER_NAME \
@@ -99,13 +100,15 @@ signerKey: config/aurora.test.near.json
 EOF
 
 echo "Starting database..."
-docker run -d --rm \
+docker run -d \
+    --restart unless-stopped \
     --network $NETWORK_NAME \
     --name $DATABASE_CONTAINER_NAME \
     $DATABASE_IMAGE_NAME
 
 echo "Starting indexer..."
-docker run -d --rm --init \
+docker run -d --init \
+    --restart unless-stopped \
     --network $NETWORK_NAME \
     -e NEAR_ENV=localnet \
     -e NODE_ENV=localnet \
@@ -115,7 +118,8 @@ docker run -d --rm --init \
     node lib/indexer.js
 
 echo "Starting endpoint..."
-docker run -d --rm --init \
+docker run -d --init \
+    --restart unless-stopped \
     --network $NETWORK_NAME \
     -e NEAR_ENV=localnet \
     -e NODE_ENV=localnet \

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -44,7 +44,7 @@ cd ..
 
 
 echo "Starting nearcore..."
-docker run -it --rm \
+docker run --rm \
     -v $(pwd)/.ci/workdir/nearData:/srv/near \
     --name $NEARCORE_CONTAINER_NAME \
     nearprotocol/nearcore:$NEARCORE_TAG \

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -15,20 +15,15 @@ docker network connect $NETWORK_NAME $RUNNER_NAME
 
 
 echo "Building database image..."
-pwd
 time docker build -t $DATABASE_IMAGE_NAME -f .docker/Dockerfile.database .
 
 
 echo "Building endpoint image..."
-pwd
 time docker build -t $ENDPOINT_IMAGE_NAME -f .docker/Dockerfile.endpoint .
 
 
-pwd
 mkdir .ci/workdir
-pwd
 cd .ci/workdir
-pwd
 
 echo "Installing near-cli..."
 git clone https://github.com/near/near-cli.git
@@ -37,8 +32,6 @@ git checkout $NEAR_CLI_HEAD
 time npm install
 cd ..
 
-pwd
-
 echo "Installing aurora-cli..."
 git clone https://github.com/aurora-is-near/aurora-cli.git
 cd aurora-cli
@@ -46,12 +39,9 @@ git checkout $AURORA_CLI_HEAD
 time npm install
 cd ..
 
-pwd
-
 mkdir nearData
-cd ..
+cd ../..
 
-pwd
 
 echo "Starting nearcore..."
 docker run --rm \
@@ -69,7 +59,6 @@ docker run -d --rm \
 echo "Sleeping for 5 seconds..."
 sleep 5
 
-pwd
 
 export NEAR_ENV=local
 

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -1,0 +1,143 @@
+#!/bin/bash -ev
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source SCRIPT_DIR/common.sh
+cd SCRIPT_DIR/..
+
+
+echo "Environment will be cleaned to avoid dirty start"
+./.ci/cleanup.sh
+
+
+echo "Establishing inner network..."
+docker network create -d bridge $NETWORK_NAME
+docker network connect $NETWORK_NAME $RUNNER_NAME
+
+
+echo "Building database image..."
+time docker build -t $DATABASE_IMAGE_NAME -f .docker/Dockerfile.database .
+
+
+echo "Building endpoint image..."
+time docker build -t $ENDPOINT_IMAGE_NAME -f .docker/Dockerfile.endpoint .
+
+
+mkdir .ci/workdir
+cd .ci/workdir
+
+echo "Installing near-cli..."
+git clone https://github.com/near/near-cli.git
+cd near-cli
+git checkout $NEAR_CLI_HEAD
+time npm ci
+cd ..
+
+echo "Installing aurora-cli..."
+git clone https://github.com/aurora-is-near/aurora-cli.git
+cd aurora-cli
+git checkout $AURORA_CLI_HEAD
+time npm ci
+cd ..
+
+mkdir nearData
+cd ..
+
+
+echo "Starting nearcore..."
+docker run -it --rm \
+    -v $(pwd)/.ci/workdir/nearData:/srv/near \
+    --name $NEARCORE_CONTAINER_NAME \
+    nearprotocol/nearcore:$NEARCORE_TAG \
+    neard --home=/srv/near init
+docker run -d --rm \
+    -v $(pwd)/.ci/workdir/nearData:/srv/near \
+    --network $NETWORK_NAME \
+    --name $NEARCORE_CONTAINER_NAME \
+    nearprotocol/nearcore:$NEARCORE_TAG \
+    neard --home=/srv/near run
+
+echo "Sleeping for 5 seconds..."
+sleep 5
+
+
+export NEAR_ENV=local
+
+echo "Creating NEAR account..."
+.ci/workdir/near-cli/bin/near create-account aurora.test.near \
+    --master-account=test.near \
+    --initial-balance 1000000 \
+    --key-path .ci/workdir/nearData/validator_key.json \
+    --node-url https://${NEARCORE_CONTAINER_NAME}:3030
+
+echo "Downloading contract..."
+curl -L $CONTRACT_URL -o .ci/workdir/contract.wasm
+
+echo "Installing contract..."
+.ci/workdir/aurora-cli/lib/aurora.js install \
+    --chain 1313161556 \
+    --owner aurora.test.near \
+    --signer aurora.test.near \
+    --engine aurora.test.near \
+    --endpoint https://${NEARCORE_CONTAINER_NAME}:3030 \
+    .ci/workdir/contract.wasm
+
+echo "Sleeping for 5 seconds..."
+sleep 5
+
+
+echo "Creating relayer configuration..."
+cp ~/.near-credentials/local/aurora.test.near.json config/aurora.test.near.json
+cat >config/local.yaml <<EOF
+---
+port: 8545
+database: postgres://aurora:aurora@${DATABASE_CONTAINER_NAME}/aurora
+network: local
+endpoint: http://${NEARCORE_CONTAINER_NAME}:3030
+engine: aurora.test.near
+signer: aurora.test.near
+signerKey: config/aurora.test.near.json
+EOF
+
+echo "Starting database..."
+docker run -d --rm \
+    --network $NETWORK_NAME \
+    --name $DATABASE_CONTAINER_NAME \
+    $DATABASE_IMAGE_NAME
+
+echo "Starting indexer..."
+docker run -d --rm --init \
+    --network $NETWORK_NAME \
+    -e NEAR_ENV=localnet \
+    -e NODE_ENV=localnet \
+    -v ./config:/srv/aurora/relayer/config \
+    --name $INDEXER_CONTAINER_NAME \
+    $ENDPOINT_IMAGE_NAME \
+    node lib/indexer.js
+
+echo "Starting endpoint..."
+docker run -d --rm --init \
+    --network $NETWORK_NAME \
+    -e NEAR_ENV=localnet \
+    -e NODE_ENV=localnet \
+    -v ./config:/srv/aurora/relayer/config \
+    --name $ENDPOINT_CONTAINER_NAME \
+    $ENDPOINT_IMAGE_NAME \
+    node lib/index.js
+
+
+echo "Putting relayer endpoint hostname to .ci/workdir/endpoint.txt"
+echo $ENDPOINT_CONTAINER_NAME > .ci/workdir/endpoint.txt
+
+
+echo "Sleeping for 30 seconds"
+sleep 30
+
+echo "[FOOBAR] DB logs:"
+docker logs $DATABASE_CONTAINER_NAME
+echo "[FOOBAR] Indexer logs:"
+docker logs $INDEXER_CONTAINER_NAME
+echo "[FOOBAR] Endpoint logs:"
+docker logs $ENDPOINT_CONTAINER_NAME
+
+
+echo "Setup finished!"

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -29,14 +29,14 @@ echo "Installing near-cli..."
 git clone https://github.com/near/near-cli.git
 cd near-cli
 git checkout $NEAR_CLI_HEAD
-time npm ci
+time npm install
 cd ..
 
 echo "Installing aurora-cli..."
 git clone https://github.com/aurora-is-near/aurora-cli.git
 cd aurora-cli
 git checkout $AURORA_CLI_HEAD
-time npm ci
+time npm install
 cd ..
 
 mkdir nearData

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -ev
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-source SCRIPT_DIR/common.sh
-cd SCRIPT_DIR/..
+source $SCRIPT_DIR/common.sh
+cd $SCRIPT_DIR/..
 
 
 echo "Environment will be cleaned to avoid dirty start"

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -2,11 +2,11 @@
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source $SCRIPT_DIR/common.sh
-cd $SCRIPT_DIR/..
 
 
 echo "Environment will be cleaned to avoid dirty start"
 ./.ci/cleanup.sh
+cd $SCRIPT_DIR/..
 
 
 echo "Establishing inner network..."
@@ -15,15 +15,20 @@ docker network connect $NETWORK_NAME $RUNNER_NAME
 
 
 echo "Building database image..."
+pwd
 time docker build -t $DATABASE_IMAGE_NAME -f .docker/Dockerfile.database .
 
 
 echo "Building endpoint image..."
+pwd
 time docker build -t $ENDPOINT_IMAGE_NAME -f .docker/Dockerfile.endpoint .
 
 
+pwd
 mkdir .ci/workdir
+pwd
 cd .ci/workdir
+pwd
 
 echo "Installing near-cli..."
 git clone https://github.com/near/near-cli.git
@@ -32,6 +37,8 @@ git checkout $NEAR_CLI_HEAD
 time npm install
 cd ..
 
+pwd
+
 echo "Installing aurora-cli..."
 git clone https://github.com/aurora-is-near/aurora-cli.git
 cd aurora-cli
@@ -39,9 +46,12 @@ git checkout $AURORA_CLI_HEAD
 time npm install
 cd ..
 
+pwd
+
 mkdir nearData
 cd ..
 
+pwd
 
 echo "Starting nearcore..."
 docker run --rm \
@@ -59,6 +69,7 @@ docker run -d --rm \
 echo "Sleeping for 5 seconds..."
 sleep 5
 
+pwd
 
 export NEAR_ENV=local
 

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -67,7 +67,7 @@ echo "Creating NEAR account..."
     --master-account=test.near \
     --initial-balance 1000000 \
     --key-path .ci/workdir/nearData/validator_key.json \
-    --node-url https://${NEARCORE_CONTAINER_NAME}:3030
+    --node-url http://${NEARCORE_CONTAINER_NAME}:3030
 
 echo "Downloading contract..."
 curl -L $CONTRACT_URL -o .ci/workdir/contract.wasm
@@ -78,7 +78,7 @@ echo "Installing contract..."
     --owner aurora.test.near \
     --signer aurora.test.near \
     --engine aurora.test.near \
-    --endpoint https://${NEARCORE_CONTAINER_NAME}:3030 \
+    --endpoint http://${NEARCORE_CONTAINER_NAME}:3030 \
     .ci/workdir/contract.wasm
 
 echo "Sleeping for 5 seconds..."

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ev
+#!/bin/bash -ex
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source $SCRIPT_DIR/common.sh

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source $SCRIPT_DIR/common.sh
@@ -28,14 +28,14 @@ cd .ci/workdir
 echo "Installing near-cli..."
 git clone https://github.com/near/near-cli.git
 cd near-cli
-git checkout $NEAR_CLI_HEAD
+git checkout -q $NEAR_CLI_HEAD
 time npm install
 cd ..
 
 echo "Installing aurora-cli..."
 git clone https://github.com/aurora-is-near/aurora-cli.git
 cd aurora-cli
-git checkout $AURORA_CLI_HEAD
+git checkout -q $AURORA_CLI_HEAD
 time npm install
 cd ..
 
@@ -128,20 +128,8 @@ docker run -d --init \
     $ENDPOINT_IMAGE_NAME \
     node lib/index.js
 
+echo "Sleeping for 5 seconds..."
+sleep 5
 
-echo "Putting relayer endpoint hostname to .ci/workdir/endpoint.txt"
+echo "Setup finished! Putting relayer endpoint hostname to .ci/workdir/endpoint.txt"
 echo $ENDPOINT_CONTAINER_NAME > .ci/workdir/endpoint.txt
-
-
-echo "Sleeping for 30 seconds"
-sleep 30
-
-echo "[FOOBAR] DB logs:"
-docker logs $DATABASE_CONTAINER_NAME
-echo "[FOOBAR] Indexer logs:"
-docker logs $INDEXER_CONTAINER_NAME
-echo "[FOOBAR] Endpoint logs:"
-docker logs $ENDPOINT_CONTAINER_NAME
-
-
-echo "Setup finished!"

--- a/.ci/show_logs.sh
+++ b/.ci/show_logs.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source $SCRIPT_DIR/common.sh
+
+
+if [[ $1 == "nearcore" ]]; then
+    docker logs $NEARCORE_CONTAINER_NAME
+elif [[ $1 == "database" ]]; then
+    docker logs $DATABASE_CONTAINER_NAME
+elif [[ $1 == "indexer" ]]; then
+    docker logs $INDEXER_CONTAINER_NAME
+elif [[ $1 == "endpoint" ]]; then
+    docker logs $ENDPOINT_CONTAINER_NAME
+else
+    echo "Unknown argument: $1"
+fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,27 @@
+---
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+name: Tests
+jobs:
+  rpc-test:
+    name: Simple RPC test
+    runs-on: self-hosted
+    steps:
+      - name: Clone the repository
+        uses: actions/checkout@v2
+      - name: Setup environment
+        run: ./.ci/setup.sh
+      - name: Test RPC
+        run: |
+          ENDPOINT_HOST=$(cat .ci/workdir/endpoint.txt)
+          curl -v -X POST \
+            -H 'Content-Type: application/json' \
+            -d '{"jsonrpc":"2.0","id":"1","method":"eth_blockNumber","params":[]}' \
+            http://${ENDPOINT_HOST}:8545
+      - name: Cleanup environment
+        if: ${{ always() }}
+        run: ./.ci/cleanup.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,10 +18,22 @@ jobs:
       - name: Test RPC
         run: |
           ENDPOINT_HOST=$(cat .ci/workdir/endpoint.txt)
-          curl -v -X POST \
+          curl -X POST \
             -H 'Content-Type: application/json' \
             -d '{"jsonrpc":"2.0","id":"1","method":"eth_blockNumber","params":[]}' \
             http://${ENDPOINT_HOST}:8545
+      - name: Print nearcore logs
+        if: ${{ always() }}
+        run: ./.ci/show_logs.sh nearcore
+      - name: Print database logs
+        if: ${{ always() }}
+        run: ./.ci/show_logs.sh database
+      - name: Print indexer logs
+        if: ${{ always() }}
+        run: ./.ci/show_logs.sh indexer
+      - name: Print endpoint logs
+        if: ${{ always() }}
+        run: ./.ci/show_logs.sh endpoint
       - name: Cleanup environment
         if: ${{ always() }}
         run: ./.ci/cleanup.sh


### PR DESCRIPTION
This PR implements CI-environment setup for RPC-tests.

Essentially, it does following things:
1. Build docker images for `database` and `endpoint`
2. Pull, init and run `nearcore`
3. Create account `aurora.test.near`
4. Install `aurora-engine` contract
5. Run `database`, `indexer` and `endpoint`

All containers are connected to Docker bridge-network, so Docker's dynamic service-discovery is used to allow containers access each other (`hostname` = `container name`).

**Important**:
Dependency versions are locked for CI consistency (nearcore, aurora-cli, near-cli, aurora-engine).
Perform manual edit on `.ci/common.sh` to update versions.
In case you don't care about version of particular dependency, just replace it with `master` (I wouldn't recommend that).

Each test-workflow should follow the same template as shown in `.github/workflows/tests.yml`:
1. Call `./.ci/setup.sh`
2. Get endpoint hostname from `./.ci/workdir/endpoint.txt`
3. Run tests
4. Print logs (if needed) by calling `./.ci/show_logs.sh [nearcore | database | indexer | endpoint]`
5. Always call `./.ci/cleanup.sh`

See how result looks like: https://github.com/aurora-is-near/aurora-relayer/runs/3751904933?check_suite_focus=true