### PR TITLE
Add automatic data-migration support for Docker deployment

### DIFF
--- a/.docker/.manifest
+++ b/.docker/.manifest
@@ -1,0 +1,1 @@
+20211221121213 node lib/data_migrations/2021-12-14-empty-blocks.js

--- a/.docker/docker-entrypoint-initdb.d/init.txt
+++ b/.docker/docker-entrypoint-initdb.d/init.txt
@@ -44,8 +44,8 @@ CREATE TYPE block_result AS (
     "size" int4,
     "gasLimit" int8,
     "gasUsed" int8,
-    "mixHash" hash,
-    "timestamp" int4
+    "timestamp" int4,
+    "mixHash" hash
 );
 DROP TYPE IF EXISTS filter_result CASCADE;
 
@@ -233,8 +233,8 @@ BEGIN
       size,                         -- size
       gas_limit,                    -- gasLimit
       gas_used,                     -- gasUsed
-      repeat('\000', 32)::hash,     -- mixHash
-      EXTRACT(EPOCH FROM timestamp) -- timestamp
+      COALESCE(EXTRACT(EPOCH FROM timestamp), 0)::int4, -- timestamp
+      repeat('\000', 32)::hash      -- mixHash
     FROM block
     WHERE id = block_id
     LIMIT 1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,11 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 2021-12-14
 
 - Run `node lib/data_migrations/2021-12-14-empty-blocks.js` to reindex all historical empty blocks.
-In addition, reload the following stored procedures:
-
-- `etc/schema/functions/eth_getBlockByNumber.sql`
-
-or
 
 ```bash
 $ cd migrations

--- a/etc/schema/functions/eth_getBlockByNumber.sql
+++ b/etc/schema/functions/eth_getBlockByNumber.sql
@@ -21,8 +21,8 @@ BEGIN
       size,                         -- size
       gas_limit,                    -- gasLimit
       gas_used,                     -- gasUsed
-      repeat('\000', 32)::hash,     -- mixHash
-      COALESCE(EXTRACT(EPOCH FROM timestamp), 0)::int4 -- timestamp
+      COALESCE(EXTRACT(EPOCH FROM timestamp), 0)::int4, -- timestamp
+      repeat('\000', 32)::hash      -- mixHash
     FROM block
     WHERE id = block_id
     LIMIT 1

--- a/etc/schema/types/block_result.sql
+++ b/etc/schema/types/block_result.sql
@@ -17,6 +17,6 @@ CREATE TYPE block_result AS (
     "size" int4,
     "gasLimit" int8,
     "gasUsed" int8,
-    "mixHash" hash,
-    "timestamp" int4
+    "timestamp" int4,
+    "mixHash" hash
 );

--- a/migrations/20211208103001_add_from_column_to_event_table.sql
+++ b/migrations/20211208103001_add_from_column_to_event_table.sql
@@ -1,5 +1,5 @@
 -- +goose Up
-ALTER TABLE event ADD COLUMN "from" address;
+ALTER TABLE event ADD COLUMN IF NOT EXISTS "from" address;
 -- +goose StatementBegin
 SELECT 'up SQL query';
 -- +goose StatementEnd

--- a/migrations/20211222141956_reload_block_result_type.sql
+++ b/migrations/20211222141956_reload_block_result_type.sql
@@ -1,0 +1,50 @@
+-- +goose Up
+-- +goose StatementBegin
+DROP TYPE IF EXISTS block_result CASCADE;
+
+CREATE TYPE block_result AS (
+    "number" blockno,
+    "hash" hash,
+    "parentHash" hash,
+    "nonce" bytea,           -- 8 bytes
+    "sha3Uncles" hash,
+    "logsBloom" bytea,       -- 256 bytes
+    "transactionsRoot" hash,
+    "stateRoot" hash,
+    "receiptsRoot" hash,
+    "miner" address,
+    "difficulty" int2,
+    "totalDifficulty" int2,
+    "extraData" bytea,       -- 0 bytes
+    "size" int4,
+    "gasLimit" int8,
+    "gasUsed" int8,
+    "mixHash" hash,
+    "timestamp" int4
+);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TYPE IF EXISTS block_result CASCADE;
+
+CREATE TYPE block_result AS (
+    "number" blockno,
+    "hash" hash,
+    "parentHash" hash,
+    "nonce" bytea,           -- 8 bytes
+    "sha3Uncles" hash,
+    "logsBloom" bytea,       -- 256 bytes
+    "transactionsRoot" hash,
+    "stateRoot" hash,
+    "receiptsRoot" hash,
+    "miner" address,
+    "difficulty" int2,
+    "totalDifficulty" int2,
+    "extraData" bytea,       -- 0 bytes
+    "size" int4,
+    "gasLimit" int8,
+    "gasUsed" int8,
+    "timestamp" int4
+);
+-- +goose StatementEnd

--- a/migrations/20211222141956_reload_block_result_type.sql
+++ b/migrations/20211222141956_reload_block_result_type.sql
@@ -1,50 +1,71 @@
 -- +goose Up
 -- +goose StatementBegin
-DROP TYPE IF EXISTS block_result CASCADE;
-
-CREATE TYPE block_result AS (
-    "number" blockno,
-    "hash" hash,
-    "parentHash" hash,
-    "nonce" bytea,           -- 8 bytes
-    "sha3Uncles" hash,
-    "logsBloom" bytea,       -- 256 bytes
-    "transactionsRoot" hash,
-    "stateRoot" hash,
-    "receiptsRoot" hash,
-    "miner" address,
-    "difficulty" int2,
-    "totalDifficulty" int2,
-    "extraData" bytea,       -- 0 bytes
-    "size" int4,
-    "gasLimit" int8,
-    "gasUsed" int8,
-    "mixHash" hash,
-    "timestamp" int4
-);
+--Make sure it will not fail on db
+ALTER TYPE block_result DROP ATTRIBUTE IF EXISTS "mixHash"; --Make sure it will not fail on db
+ALTER TYPE block_result ADD ATTRIBUTE "mixHash" hash;
+-- Move mixHash to the end, since order is important
+CREATE OR REPLACE FUNCTION eth_getBlockByNumber(block_id blockno) RETURNS block_result AS $$
+DECLARE
+  result block_result;
+BEGIN
+  SELECT
+      id,                           -- number
+      hash,                         -- hash
+      parent_hash,                  -- parentHash
+      repeat('\000', 8)::bytea,     -- nonce
+      '\x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347',    -- sha3Uncles keccak256(rlp.encode([]))
+      repeat('\000', 256)::bytea,   -- logsBloom
+      transactions_root,            -- transactionsRoot
+      state_root,                   -- stateRoot
+      receipts_root,                -- receiptsRoot
+      repeat('\000', 20)::bytea,    -- miner
+      0,                            -- difficulty
+      0,                            -- totalDifficulty
+      ''::bytea,                    -- extraData
+      size,                         -- size
+      gas_limit,                    -- gasLimit
+      gas_used,                     -- gasUsed
+      COALESCE(EXTRACT(EPOCH FROM timestamp), 0)::int4, -- timestamp
+      repeat('\000', 32)::hash      -- mixHash
+    FROM block
+    WHERE id = block_id
+    LIMIT 1
+    INTO STRICT result;
+  RETURN result;
+END;
+$$ LANGUAGE plpgsql VOLATILE PARALLEL UNSAFE;
 -- +goose StatementEnd
 
 -- +goose Down
 -- +goose StatementBegin
-DROP TYPE IF EXISTS block_result CASCADE;
-
-CREATE TYPE block_result AS (
-    "number" blockno,
-    "hash" hash,
-    "parentHash" hash,
-    "nonce" bytea,           -- 8 bytes
-    "sha3Uncles" hash,
-    "logsBloom" bytea,       -- 256 bytes
-    "transactionsRoot" hash,
-    "stateRoot" hash,
-    "receiptsRoot" hash,
-    "miner" address,
-    "difficulty" int2,
-    "totalDifficulty" int2,
-    "extraData" bytea,       -- 0 bytes
-    "size" int4,
-    "gasLimit" int8,
-    "gasUsed" int8,
-    "timestamp" int4
-);
+ALTER TYPE block_result DROP ATTRIBUTE IF EXISTS "mixHash";
+CREATE OR REPLACE FUNCTION eth_getBlockByNumber(block_id blockno) RETURNS block_result AS $$
+DECLARE
+  result block_result;
+BEGIN
+  SELECT
+      id,                           -- number
+      hash,                         -- hash
+      parent_hash,                  -- parentHash
+      repeat('\000', 8)::bytea,     -- nonce
+      '\x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347',    -- sha3Uncles keccak256(rlp.encode([]))
+      repeat('\000', 256)::bytea,   -- logsBloom
+      transactions_root,            -- transactionsRoot
+      state_root,                   -- stateRoot
+      receipts_root,                -- receiptsRoot
+      repeat('\000', 20)::bytea,    -- miner
+      0,                            -- difficulty
+      0,                            -- totalDifficulty
+      ''::bytea,                    -- extraData
+      size,                         -- size
+      gas_limit,                    -- gasLimit
+      gas_used,                     -- gasUsed
+      COALESCE(EXTRACT(EPOCH FROM timestamp), 0)::int4 -- timestamp
+    FROM block
+    WHERE id = block_id
+    LIMIT 1
+    INTO STRICT result;
+  RETURN result;
+END;
+$$ LANGUAGE plpgsql VOLATILE PARALLEL UNSAFE;
 -- +goose StatementEnd


### PR DESCRIPTION
* Adding `.manifest` for data migration that can be used during docker deployment

* Modify `20211208103001_add_from_column_to_event_table.sql` so it will not fail on `event` table that already has `from` column.

* Add missing migration for `mixHash` attribute in  `block_result` type

* Change attributes order of `block_result` type to simplify migration