### PR TITLE
Avoid 'BUFFER_OVERRUN' error for unsupported revert reason. Resolves #165

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -44,8 +44,12 @@ export function parseEVMRevertReason(reason) {
     if (reason.length > 0) {
         // only for valid decoded revert reason
         const coder = new ethers.utils.AbiCoder();
-        const result = coder.decode(['string'], reason.slice(4));
-        return result.toString();
+        try {
+            return coder.decode(['string'], reason.slice(4)).toString();
+        }
+        catch {
+            return reason;
+        }
     }
     return reason;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -79,8 +79,11 @@ export function parseEVMRevertReason(reason: Uint8Array): string | Uint8Array {
   if (reason.length > 0) {
     // only for valid decoded revert reason
     const coder = new ethers.utils.AbiCoder();
-    const result = coder.decode(['string'], reason.slice(4));
-    return result.toString();
+    try {
+      return coder.decode(['string'], reason.slice(4)).toString();
+    } catch {
+      return reason;
+    }
   }
   return reason;
 }


### PR DESCRIPTION
On some reverts reason can not be decoded. Thus let's avoid raising `BUFFER_OVERRUN` which is not informative.