### PR TITLE
Add buildchain CI

### DIFF
--- a/.github/workflows/buildchain.yml
+++ b/.github/workflows/buildchain.yml
@@ -31,22 +31,25 @@ jobs:
         run: apt-get install uuid-runtime
 
       - name: Configure
-        run: ./buildchain/cfg_template/client/configure.sh /etc/buildchain-client
+        run: |
+          mkdir -p /etc/buildchain-client
+          echo "$NATS_CREDS" > /etc/buildchain-client/nats.creds
+          echo "$REMAPHORE_CONFIG" > /etc/buildchain-client/remaphore.conf
         env:
           NATS_CREDS: ${{secrets.BUILDCHAIN_REMAPHORE_NATS_CREDS}}
-          CLIENT_DESTINATION: buildchain.ci_client
-          CLIENT_PUB_KEY: ${{secrets.BUILDCHAIN_CI_CLIENT_REMAPHORE_PUBLIC_KEY}}
-          CLIENT_PRIV_KEY: ${{secrets.BUILDCHAIN_CI_CLIENT_REMAPHORE_PRIVATE_KEY}}
-          SERVER_DESTINATION: buildchain.builder
-          SERVER_PUB_KEY: ${{secrets.BUILDCHAIN_BUILDER_REMAPHORE_PUBLIC_KEY}}
-          VERBS: build_relayer
+          REMAPHORE_CONFIG: ${{secrets.BUILDCHAIN_CLIENT_CONFIG}}
 
       - name: Run build
         run: |
-          ./buildchain/client/run.sh \
-            buildchain.builder \
-            build_relayer \
-            "$GITHUB_REF_NAME $GITHUB_SHA"
+          ./buildchain/client/run.sh buildchain.builder \
+            build_relayer "$GITHUB_REF_NAME $GITHUB_SHA"
+        env:
+          BUILDCHAIN_CLIENT_REMAPHORE_CONFIG: /etc/buildchain-client/remaphore.conf
+
+      - name: Run testing/beta deploy
+        run: |
+          ./buildchain/client/run.sh buildchain.relayer_tester \
+            build_relayer "$GITHUB_REF_NAME $GITHUB_SHA"
         env:
           BUILDCHAIN_CLIENT_REMAPHORE_CONFIG: /etc/buildchain-client/remaphore.conf
 

--- a/.github/workflows/buildchain.yml
+++ b/.github/workflows/buildchain.yml
@@ -1,0 +1,39 @@
+---
+on:
+  push:
+    branches:
+      - master
+      - testnet
+      - buildchain-ci
+
+name: Buildchain
+jobs:
+
+  build:
+    name: Build
+    runs-on: [self-hosted, light]
+    steps:
+
+      - name: Clone the repository
+        uses: actions/checkout@v2
+
+      - name: Clone buildchain repository
+        uses: actions/checkout@v2
+        with:
+          repository: aurora-is-near/buildchain
+          ssh-key: ${{ secrets.BUILDCHAIN_REPO_SSH_KEY }}
+          path: buildchain
+
+      - name: Install remaphore
+        run: go get -u -v github.com/aurora-is-near/remaphore/cmd/remaphore
+
+      - name: Configure
+        run: ./buildchain/cfg_template/client/configure.sh /etc/buildchain-client
+        env:
+          NATS_CREDS: ${{secrets.BUILDCHAIN_REMAPHORE_NATS_CREDS}}
+          CLIENT_DESTINATION: buildchain.ci_client
+          CLIENT_PUB_KEY: ${{secrets.BUILDCHAIN_CI_CLIENT_REMAPHORE_PUBLIC_KEY}}
+          CLIENT_PRIV_KEY: ${{secrets.BUILDCHAIN_CI_CLIENT_REMAPHORE_PRIVATE_KEY}}
+          SERVER_DESTINATION: buildchain.builder
+          SERVER_PUB_KEY: ${{secrets.BUILDCHAIN_BUILDER_REMAPHORE_PUBLIC_KEY}}
+          VERBS: build_relayer

--- a/.github/workflows/buildchain.yml
+++ b/.github/workflows/buildchain.yml
@@ -9,8 +9,8 @@ on:
 name: Buildchain
 jobs:
 
-  build:
-    name: Build
+  buildchain:
+    name: Buildchain
     runs-on: [self-hosted, light]
     steps:
 
@@ -45,13 +45,15 @@ jobs:
             build_relayer "$GITHUB_REF_NAME $GITHUB_SHA"
         env:
           BUILDCHAIN_CLIENT_REMAPHORE_CONFIG: /etc/buildchain-client/remaphore.conf
+        timeout-minutes: 15
 
-      - name: Run testing/beta deploy
+      - name: Run testing & beta deploy
         run: |
           ./buildchain/client/run.sh buildchain.relayer_tester \
-            build_relayer "$GITHUB_REF_NAME $GITHUB_SHA"
+            test_relayer "$GITHUB_REF_NAME $GITHUB_SHA"
         env:
           BUILDCHAIN_CLIENT_REMAPHORE_CONFIG: /etc/buildchain-client/remaphore.conf
+        timeout-minutes: 70
 
       - name: Cleanup
         if: ${{ always() }}

--- a/.github/workflows/buildchain.yml
+++ b/.github/workflows/buildchain.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Install remaphore
         run: go get -u -v github.com/aurora-is-near/remaphore/cmd/remaphore
 
+      - name: Install uuidgen
+        run: apt-get install uuid-runtime
+
       - name: Configure
         run: ./buildchain/cfg_template/client/configure.sh /etc/buildchain-client
         env:

--- a/.github/workflows/buildchain.yml
+++ b/.github/workflows/buildchain.yml
@@ -3,8 +3,8 @@ on:
   push:
     branches:
       - master
+      - mainnet
       - testnet
-      - buildchain-ci
 
 name: Buildchain
 jobs:

--- a/.github/workflows/buildchain.yml
+++ b/.github/workflows/buildchain.yml
@@ -46,11 +46,9 @@ jobs:
           ./buildchain/client/run.sh \
             buildchain.builder \
             build_relayer \
-            "$BRANCH $COMMIT_HASH"
+            "$GITHUB_REF_NAME $GITHUB_SHA"
         env:
           BUILDCHAIN_CLIENT_REMAPHORE_CONFIG: /etc/buildchain-client/remaphore.conf
-          BRANCH: ${{env.GITHUB_REF_NAME}}
-          COMMIT_HASH: ${{env.GITHUB_SHA}}
 
       - name: Cleanup
         if: ${{ always() }}

--- a/.github/workflows/buildchain.yml
+++ b/.github/workflows/buildchain.yml
@@ -37,3 +37,18 @@ jobs:
           SERVER_DESTINATION: buildchain.builder
           SERVER_PUB_KEY: ${{secrets.BUILDCHAIN_BUILDER_REMAPHORE_PUBLIC_KEY}}
           VERBS: build_relayer
+
+      - name: Run build
+        run: |
+          ./buildchain/client/run.sh \
+            buildchain.builder \
+            build_relayer \
+            "$BRANCH $COMMIT_HASH"
+        env:
+          BUILDCHAIN_CLIENT_REMAPHORE_CONFIG: /etc/buildchain-client/remaphore.conf
+          BRANCH: ${{GITHUB_REF_NAME}}
+          COMMIT_HASH: ${{GITHUB_SHA}}
+
+      - name: Cleanup
+        if: ${{ always() }}
+        run: rm -rf /etc/buildchain-client || true

--- a/.github/workflows/buildchain.yml
+++ b/.github/workflows/buildchain.yml
@@ -46,8 +46,8 @@ jobs:
             "$BRANCH $COMMIT_HASH"
         env:
           BUILDCHAIN_CLIENT_REMAPHORE_CONFIG: /etc/buildchain-client/remaphore.conf
-          BRANCH: ${{GITHUB_REF_NAME}}
-          COMMIT_HASH: ${{GITHUB_SHA}}
+          BRANCH: ${{env.GITHUB_REF_NAME}}
+          COMMIT_HASH: ${{env.GITHUB_SHA}}
 
       - name: Cleanup
         if: ${{ always() }}


### PR DESCRIPTION
This CI:
1. Triggers buildserver to fetch, build and push to internal registry
2. If build succeeded, triggers beta deploy & health-testing (including successful migration, block progression and lifetime checks)