### PR TITLE
Update status for eth_getLogs and eth_getTransactionReceipt

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,14 +115,14 @@ Method | Status | Notes
 [`eth_getCompilers`] | ✅ |
 [`eth_getFilterChanges`] | 🚧 |
 [`eth_getFilterLogs`] | 🚧 |
-[`eth_getLogs`] | 🚧 |
+[`eth_getLogs`] | ✅ |
 [`eth_getProof`] | ❌ | EIP-1186
 [`eth_getStorageAt`] | ✅ |
 [`eth_getTransactionByBlockHashAndIndex`] | ✅ |
 [`eth_getTransactionByBlockNumberAndIndex`] | ✅ |
 [`eth_getTransactionByHash`] | 🚧 |
 [`eth_getTransactionCount`] | ✅ |
-[`eth_getTransactionReceipt`] | 🚧 |
+[`eth_getTransactionReceipt`] | ✅ |
 [`eth_getUncleByBlockHashAndIndex`] | ✅ |
 [`eth_getUncleByBlockNumberAndIndex`] | ✅ |
 [`eth_getUncleCountByBlockHash`] | ✅ |


### PR DESCRIPTION
It seems that the status for these RPCs are stale. I have a dependency on them and I'm documenting why I think these endpoints are already working
- Queries to https://mainnet.aurora.dev/ for these methods succeed (attempted with tx hash 0x369b11a12d63b5531b3f3caa7667bb20801b83944a7daeb34a417699e7f0af86 and block 64054400)
- aurorascan.dev is indexing logs, I'm not sure how one would do it without one of these RPCs ([example](https://aurorascan.dev/tx/0x369b11a12d63b5531b3f3caa7667bb20801b83944a7daeb34a417699e7f0af86))
- I also see the code for eth_getLogs in the repo, and a PR (#22) related to the endpoint