### PR TITLE
Fix WebSockets init

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -128,10 +128,10 @@ function parseTransactionDetails(message) {
     }
 }
 function rpcMiddleware(server) {
-    return async function (req, res) {
+    return async function (req, res, next) {
         const options = server.options;
         if (req.headers['sec-websocket-key']) {
-            res.next();
+            return next();
         }
         if ((req.method || '') != 'POST') {
             return error(405, { Allow: 'POST' });

--- a/src/app.ts
+++ b/src/app.ts
@@ -212,11 +212,11 @@ function parseTransactionDetails(
 }
 
 function rpcMiddleware(server: jayson.Server): any {
-  return async function (req: any, res: any): Promise<any> {
+  return async function (req: any, res: any, next: any): Promise<any> {
     const options: any = server.options;
 
     if (req.headers['sec-websocket-key']) {
-      res.next();
+      return next();
     }
 
     if ((req.method || '') != 'POST') {


### PR DESCRIPTION
### Before

```
wscat -c ws://localhost:8545                                                                                                                             
Connected (press CTRL+C to quit)
Disconnected (code: 1006, reason: "")

Relayer for the NEAR Testnet listening at http://localhost:8545...
file:///Users/zak/dev/aurora/aurora-relayer/lib/app.js:134
            res.next();
                ^

TypeError: res.next is not a function
```


### After

```
[~/dev/aurora/aurora-relayer]$ wscat -c ws://localhost:8545                                                                                                                                 
Connected (press CTRL+C to quit)
> {"jsonrpc": "2.0", "id": 1, "method": "eth_getBlockByNumber", "params": ["latest", true] }
< {"jsonrpc":"2.0","id":1,"result":{"number":"0x541203d","hash":"0x85179c9130aa39dfe7be66036940869dc2f709bc2a9a7bd0b87fb2b7ebe13a66","parentHash":"0xb146b9bdd3878f828b08bc9f80c4c0cc6147a22b0ae172bcb97a84486df31af1","nonce":"0x0000000000000000","sha3Uncles":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","transactionsRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","stateRoot":"0x0000000000000000000000000000000000000000000000000000000000000000","receiptsRoot":"0x0000000000000000000000000000000000000000000000000000000000000000","miner":"0x0000000000000000000000000000000000000000","difficulty":"0x0","totalDifficulty":"0x0","extraData":"0x","size":"0x0","gasLimit":"0x0","gasUsed":"0x0","timestamp":"0x0","mixHash":"0x0000000000000000000000000000000000000000000000000000000000000000","uncles":[],"transactions":[]}}
> {"jsonrpc": "2.0", "id": 1, "method": "eth_getBlockByNumber", "params": ["latest", true] }
< {"jsonrpc":"2.0","id":1,"result":{"number":"0x541203d","hash":"0x85179c9130aa39dfe7be66036940869dc2f709bc2a9a7bd0b87fb2b7ebe13a66","parentHash":"0xb146b9bdd3878f828b08bc9f80c4c0cc6147a22b0ae172bcb97a84486df31af1","nonce":"0x0000000000000000","sha3Uncles":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","transactionsRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","stateRoot":"0x0000000000000000000000000000000000000000000000000000000000000000","receiptsRoot":"0x0000000000000000000000000000000000000000000000000000000000000000","miner":"0x0000000000000000000000000000000000000000","difficulty":"0x0","totalDifficulty":"0x0","extraData":"0x","size":"0x0","gasLimit":"0x0","gasUsed":"0x0","timestamp":"0x0","mixHash":"0x0000000000000000000000000000000000000000000000000000000000000000","uncles":[],"transactions":[]}}
```