### PR TITLE
Change response of event when there are no topics

### DIFF
--- a/lib/servers/database.js
+++ b/lib/servers/database.js
@@ -547,7 +547,7 @@ export class DatabaseServer extends SkeletonServer {
         return rows.map((row) => {
             row['topics'] =
                 row['topics'] === null
-                    ? null
+                    ? []
                     : row['topics']
                         .split(';')
                         .map((topic) => topic.replace('\\x', '0x'));

--- a/src/servers/database.ts
+++ b/src/servers/database.ts
@@ -837,7 +837,7 @@ export class DatabaseServer extends SkeletonServer {
     return rows.map((row: Record<string, unknown>) => {
       row['topics'] =
         row['topics'] === null
-          ? null
+          ? []
           : (row['topics'] as string)
               .split(';')
               .map((topic) => topic.replace('\\x', '0x'));


### PR DESCRIPTION
Relative to: https://github.com/aurora-is-near/aurora-relayer/issues/280

```
package main

import (
	"context"
	"fmt"
	"github.com/ethereum/go-ethereum/ethclient"
	"github.com/ethereum/go-ethereum/common"
)

func main() {
	rpc := "https://mainnet.aurora.dev"
	// rpc := "http://localhost:8545"
	client, err := ethclient.Dial(rpc)
	if err != nil {
		panic(err)
	}

	txHash := common.HexToHash("0xd09dbc30579d2902ec6378ff5098b17b15aaa0ecac5bcd0ff5946bf64e55e7a4")
	receipt, err := client.TransactionReceipt(context.Background(), txHash)
	if err != nil {
		panic(err)
	}
	fmt.Printf("Receipt %+v\n", receipt)
}
```

Before:
```
$ go run index.go
panic: missing required field 'topics' for Log

goroutine 1 [running]:
main.main()
	/Users/zak/dev/aurora/go-examples/first/index.go:20 +0x11c
exit status 2
```

```
{
    "blockNumber": "0x3dfdf53",
    "blockHash": "0xd369a15a57899c0ff686243e5553d3f57ef5dc392f7252c7c43399bf0900c9a0",
    "transactionIndex": "0x0",
    "transactionHash": "0xd09dbc30579d2902ec6378ff5098b17b15aaa0ecac5bcd0ff5946bf64e55e7a4",
    "logIndex": "0xa",
    "address": "0xf968ae76b67e0ac34ebd27dbe7157c43ec6124e7",
    "topics": null,
    "data": "0x01b57416f6012a0bc42c30ac6cc15fac9bd938618bcaa1a1fae8501d0000000254b327dd6873c23d358a",
    "removed": false
},
```

After:
```
$ go run index.go

Receipt &{Type:0 PostState:[] Status:1 CumulativeGasUsed:0 Bloom:[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] Logs:[0x1400013a4d0 0x1400013a580 0x1400013a630 0x1400013a6e0 0x1400013a790 0x1400013a840 0x1400013a8f0 0x1400013a9a0 0x1400013aa50 0x1400013ab00 0x1400013abb0 0x1400013ac60 0x1400013ad10] TxHash:0xd09dbc30579d2902ec6378ff5098b17b15aaa0ecac5bcd0ff5946bf64e55e7a4 ContractAddress:0x0000000000000000000000000000000000000000 GasUsed:181551 BlockHash:0xd369a15a57899c0ff686243e5553d3f57ef5dc392f7252c7c43399bf0900c9a0 BlockNumber:+65003347 TransactionIndex:0}
```


```
{
    "blockNumber": "0x3dfdf53",
    "blockHash": "0xd369a15a57899c0ff686243e5553d3f57ef5dc392f7252c7c43399bf0900c9a0",
    "transactionIndex": "0x0",
    "transactionHash": "0xd09dbc30579d2902ec6378ff5098b17b15aaa0ecac5bcd0ff5946bf64e55e7a4",
    "logIndex": "0xa",
    "address": "0xf968ae76b67e0ac34ebd27dbe7157c43ec6124e7",
    "topics": [],
    "data": "0x01b57416f6012a0bc42c30ac6cc15fac9bd938618bcaa1a1fae8501d0000000254b327dd6873c23d358a",
    "removed": false
},
```