### PR TITLE
Fixed  txs for 'latest' block

### DIFF
--- a/.github/workflows/testnet-tests.yml
+++ b/.github/workflows/testnet-tests.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - master
   pull_request:
-    types: [labeled]
 
 name: Tests for testnet
 jobs:

--- a/lib/servers/database.d.ts
+++ b/lib/servers/database.d.ts
@@ -37,7 +37,7 @@ export declare class DatabaseServer extends SkeletonServer {
     eth_subscribe(_request: Request, _subsciptionType: web3.Data, _filter: any): Promise<web3.Data>;
     eth_uninstallFilter(_request: Request, filterID: web3.Quantity): Promise<boolean>;
     eth_unsubscribe(_request: Request, _subsciptionId: web3.Data): Promise<boolean>;
-    protected _fetchCurrentBlockID(): Promise<number>;
+    protected _fetchCurrentBlockID(): Promise<bigint>;
     protected _fetchEvents(transactionID: Uint8Array): Promise<unknown[]>;
-    protected _fetchTransactions(blockID: number | Uint8Array, fullObject: boolean): Promise<unknown[] | string[]>;
+    protected _fetchTransactions(blockID: bigint | number | Uint8Array, fullObject: boolean): Promise<unknown[] | string[]>;
 }

--- a/lib/servers/database.js
+++ b/lib/servers/database.js
@@ -564,7 +564,7 @@ export class DatabaseServer extends SkeletonServer {
         });
     }
     async _fetchTransactions(blockID, fullObject) {
-        const idColumn = typeof blockID === 'number' ? 'id' : 'hash';
+        const idColumn = ['bigint', 'number'].includes(typeof blockID) ? 'id' : 'hash';
         if (fullObject) {
             const { rows } = await this._query(`SELECT
             b.id AS "blockNumber",

--- a/lib/servers/database.js
+++ b/lib/servers/database.js
@@ -564,7 +564,9 @@ export class DatabaseServer extends SkeletonServer {
         });
     }
     async _fetchTransactions(blockID, fullObject) {
-        const idColumn = ['bigint', 'number'].includes(typeof blockID) ? 'id' : 'hash';
+        const idColumn = ['bigint', 'number'].includes(typeof blockID)
+            ? 'id'
+            : 'hash';
         if (fullObject) {
             const { rows } = await this._query(`SELECT
             b.id AS "blockNumber",

--- a/src/servers/database.ts
+++ b/src/servers/database.ts
@@ -863,7 +863,9 @@ export class DatabaseServer extends SkeletonServer {
     blockID: number | Uint8Array,
     fullObject: boolean
   ): Promise<unknown[] | string[]> {
-    const idColumn = typeof blockID === 'number' ? 'id' : 'hash';
+    const idColumn = ['bigint', 'number'].includes(typeof blockID)
+      ? 'id'
+      : 'hash';
     if (fullObject) {
       const { rows } = await this._query(
         `SELECT

--- a/src/servers/database.ts
+++ b/src/servers/database.ts
@@ -822,7 +822,7 @@ export class DatabaseServer extends SkeletonServer {
     return true;
   }
 
-  protected async _fetchCurrentBlockID(): Promise<number> {
+  protected async _fetchCurrentBlockID(): Promise<bigint> {
     const {
       rows: [{ result }],
     } = await this._query('SELECT eth_blockNumber() AS result');
@@ -860,7 +860,7 @@ export class DatabaseServer extends SkeletonServer {
   }
 
   protected async _fetchTransactions(
-    blockID: number | Uint8Array,
+    blockID: bigint | number | Uint8Array,
     fullObject: boolean
   ): Promise<unknown[] | string[]> {
     const idColumn = ['bigint', 'number'].includes(typeof blockID)


### PR DESCRIPTION
This: 

https://github.com/aurora-is-near/aurora-relayer/blob/d7b2de6e4f0f879a6d4f54218c41dce500b0c4e4/src/servers/database.ts#L828

Started to return `bigint` instead of `number`, so 

https://github.com/aurora-is-near/aurora-relayer/blob/d7b2de6e4f0f879a6d4f54218c41dce500b0c4e4/src/servers/database.ts#L866

no longer selects `idColumn` properly