### PR TITLE
Fix warning during tests run

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "format": "prettier -w src",
     "lint": "eslint test && eslint **/*.ts",
     "start": "nodemon",
-    "test": "jest --forceExit",
+    "test": "NODE_ENV= jest --forceExit",
     "build:schema": "cat etc/schema.sql | cut -d' ' -f2 | xargs cat > .docker/docker-entrypoint-initdb.d/init.txt"
   },
   "keywords": [


### PR DESCRIPTION
Before
```
 PASS  test/rpc_methods/eth_uninstallFilter.test.ts
  ● Console

    console.error
      WARNING: NODE_ENV value of 'test' did not match any deployment config file names.

      at _warnOrThrow (node_modules/config/lib/config.js:1481:13)
      at node_modules/config/lib/config.js:1460:7
          at Array.forEach (<anonymous>)
      at Config.Object.<anonymous>.util.runStrictnessChecks (node_modules/config/lib/config.js:1453:12)
      at new Config (node_modules/config/lib/config.js:120:8)
      at Object.<anonymous> (node_modules/config/lib/config.js:1492:31)

    console.error
      WARNING: See https://github.com/lorenwest/node-config/wiki/Strict-Mode

      at _warnOrThrow (node_modules/config/lib/config.js:1482:13)
      at node_modules/config/lib/config.js:1460:7
          at Array.forEach (<anonymous>)
      at Config.Object.<anonymous>.util.runStrictnessChecks (node_modules/config/lib/config.js:1453:12)
      at new Config (node_modules/config/lib/config.js:120:8)
      at Object.<anonymous> (node_modules/config/lib/config.js:1492:31)
```

After
```
PASS  test/rpc_methods/eth_uninstallFilter.test.ts
```