### PR TITLE
Add limit for logs

### DIFF
--- a/lib/config.d.ts
+++ b/lib/config.d.ts
@@ -17,6 +17,7 @@ export interface Config {
     writable?: boolean;
     errorLog?: string;
     minGasPrice?: number;
+    getLogsLimit: number;
 }
 export declare const localConfig: Config;
 export declare function parseConfig(options: Config, config: Config, env: ConnectEnv): [NetworkConfig, Config];

--- a/lib/config.js
+++ b/lib/config.js
@@ -16,6 +16,7 @@ export const localConfig = {
     writable: true,
     errorLog: undefined,
     minGasPrice: undefined,
+    getLogsLimit: 10000,
 };
 export function parseConfig(options, config, env) {
     const networkID = options.network || env.NEAR_ENV || config.network;
@@ -52,6 +53,7 @@ export function parseConfig(options, config, env) {
             writable: config.writable !== undefined ? config.writable : true,
             errorLog: config.errorLog,
             minGasPrice: config.minGasPrice !== undefined ? config.minGasPrice : 0,
+            getLogsLimit: options.getLogsLimit || config.getLogsLimit || 10000,
         },
     ];
 }

--- a/lib/errors.d.ts
+++ b/lib/errors.d.ts
@@ -42,3 +42,6 @@ export declare class RevertError extends ExpectedError {
 export declare class GasPriceTooLow extends ExpectedError {
     constructor(message?: string);
 }
+export declare class LimitExceeded extends ExpectedError {
+    constructor(limit: number, message?: string);
+}

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -102,3 +102,9 @@ export class GasPriceTooLow extends ExpectedError {
         Object.setPrototypeOf(this, InvalidAddress.prototype);
     }
 }
+export class LimitExceeded extends ExpectedError {
+    constructor(limit, message) {
+        super(-32005, message || `query returned more than ${limit} results`);
+        Object.setPrototypeOf(this, InvalidAddress.prototype);
+    }
+}

--- a/lib/server.js
+++ b/lib/server.js
@@ -26,8 +26,8 @@ export class Method extends jayson.Method {
             .catch((error) => {
             const metadata = {
                 host: request?.headers?.host || undefined,
-                'cf-ray': request?.headers['cf-ray'] || undefined,
-                'cf-request-id': request?.headers['cf-request-id'] || undefined,
+                'cf-ray': request?.headers?.['cf-ray'] || undefined,
+                'cf-request-id': request?.headers?.['cf-request-id'] || undefined,
             };
             if (error instanceof ExpectedError) {
                 return callback(server.error(error.code, error.message, error.data

--- a/lib/servers/database.js
+++ b/lib/servers/database.js
@@ -2,7 +2,7 @@
 import { SkeletonServer } from './skeleton.js';
 import { Bus } from '../bus.js';
 import { pg, sql } from '../database.js';
-import { InvalidAddress, InvalidArguments, RevertError, TransactionError, UnexpectedError, UnknownFilter, UnsupportedMethod, GasPriceTooLow, } from '../errors.js';
+import { InvalidAddress, InvalidArguments, RevertError, TransactionError, UnexpectedError, UnknownFilter, UnsupportedMethod, GasPriceTooLow, LimitExceeded, } from '../errors.js';
 import { compileTopics } from '../topics.js';
 import { parse } from 'postgres-array';
 import { Address, bytesToHex, exportJSON, formatU256, hexToBytes, hexToInt, intToHex, } from '@aurora-is-near/engine';
@@ -10,7 +10,6 @@ import fs from 'fs';
 import { getRandomBytesSync } from 'ethereum-cryptography/random.js';
 import { parse as parseRawTransaction, } from '@ethersproject/transactions';
 import { keccak256 } from 'ethereumjs-util';
-const GET_LOGS_LIMIT = 10000;
 export class DatabaseServer extends SkeletonServer {
     async _init() {
         // Connect to the PostgreSQL database:
@@ -259,13 +258,16 @@ export class DatabaseServer extends SkeletonServer {
         if (typeof filter.index === 'number') {
             where.push({ 't.index': filter.index });
         }
-        const query = sql
+        let query = sql
             .select('b.id AS "blockNumber"', 'b.hash AS "blockHash"', 't.index AS "transactionIndex"', 't.hash AS "transactionHash"', 'e.index AS "logIndex"', 'e.from AS "address"', "string_to_array(concat('0x',encode(e.topics[1], 'hex'), ',', '0x', encode(e.topics[2], 'hex'), ',', '0x', encode(e.topics[3], 'hex'), ',', '0x', encode(e.topics[4], 'hex')), ',') AS \"topics\"", 'coalesce(e.data, repeat(\'\\000\', 32)::bytea) AS "data"', '0::boolean AS "removed"')
             .from('event e')
-            .leftJoin('transaction t', { 'e.transaction': 't.id' })
-            .leftJoin('block b', { 't.block': 'b.id' })
+            .join('transaction t', { 'e.transaction': 't.id' })
+            .join('block b', { 't.block': 'b.id' })
             .where(sql.and(...where))
-            .limit(GET_LOGS_LIMIT);
+            .orderBy('b.id ASC');
+        if (this.config.getLogsLimit) {
+            query = query.limit(this.config.getLogsLimit + 1);
+        }
         if (this.config.debug) {
             console.debug('eth_getLogs', 'query:', query.toParams());
             console.debug('eth_getLogs', 'query:', query.toString());
@@ -274,7 +276,7 @@ export class DatabaseServer extends SkeletonServer {
         if (this.config.debug) {
             console.debug('eth_getLogs', 'result:', rows);
         }
-        return exportJSON(rows.map((row) => {
+        const events = rows.map((row) => {
             if (row['address'] === null) {
                 row['address'] = Address.zero().toString();
             }
@@ -285,7 +287,11 @@ export class DatabaseServer extends SkeletonServer {
                 });
             }
             return row;
-        }));
+        });
+        if (this.config.getLogsLimit && events.length > this.config.getLogsLimit) {
+            throw new LimitExceeded(this.config.getLogsLimit);
+        }
+        return exportJSON(events);
     }
     async eth_getStorageAt(_request, address, key, blockNumber) {
         const address_ = parseAddress(address);
@@ -590,17 +596,18 @@ export class DatabaseServer extends SkeletonServer {
                 where.push(clauses);
             }
         }
-        const query = sql
+        let query = sql
             .select('b.id AS "blockNumber"', 'b.hash AS "blockHash"', 't.index AS "transactionIndex"', 't.hash AS "transactionHash"', 'e.index AS "logIndex"', 'e.from AS "address"', "string_to_array(concat('0x',encode(e.topics[1], 'hex'), ',', '0x', encode(e.topics[2], 'hex'), ',', '0x', encode(e.topics[3], 'hex'), ',', '0x', encode(e.topics[4], 'hex')), ',') AS \"topics\"", 'coalesce(e.data, repeat(\'\\000\', 32)::bytea) AS "data"', '0::boolean AS "removed"')
             .from('event e')
-            .leftJoin('transaction t', { 'e.transaction': 't.id' })
-            .leftJoin('block b', { 't.block': 'b.id' })
+            .join('transaction t', { 'e.transaction': 't.id' })
+            .join('block b', { 't.block': 'b.id' })
             .where(sql.and(...where))
-            .limit(GET_LOGS_LIMIT)
             .orderBy('b.id ASC');
-        const result = await this._query(query);
-        await this._updatePollBlock(filterID_);
-        return exportJSON(result.rows.map((row) => {
+        if (this.config.getLogsLimit) {
+            query = query.limit(this.config.getLogsLimit + 1);
+        }
+        const { rows } = await this._query(query);
+        const events = rows.map((row) => {
             if (row['address'] === null) {
                 row['address'] = Address.zero().toString();
             }
@@ -611,7 +618,12 @@ export class DatabaseServer extends SkeletonServer {
                 });
             }
             return row;
-        }));
+        });
+        if (this.config.getLogsLimit && events.length > this.config.getLogsLimit) {
+            throw new LimitExceeded(this.config.getLogsLimit);
+        }
+        await this._updatePollBlock(filterID_);
+        return exportJSON(events);
     }
     async _fetchCurrentBlockID() {
         const { rows: [{ result }], } = await this._query('SELECT eth_blockNumber() AS result');

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,7 @@ export interface Config {
   writable?: boolean;
   errorLog?: string;
   minGasPrice?: number;
+  getLogsLimit: number;
 }
 
 export const localConfig: Config = {
@@ -38,6 +39,7 @@ export const localConfig: Config = {
   writable: true,
   errorLog: undefined,
   minGasPrice: undefined,
+  getLogsLimit: 10000,
 };
 
 export function parseConfig(
@@ -83,6 +85,7 @@ export function parseConfig(
       writable: config.writable !== undefined ? config.writable : true,
       errorLog: config.errorLog,
       minGasPrice: config.minGasPrice !== undefined ? config.minGasPrice : 0,
+      getLogsLimit: options.getLogsLimit || config.getLogsLimit || 10000,
     },
   ];
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -123,3 +123,10 @@ export class GasPriceTooLow extends ExpectedError {
     Object.setPrototypeOf(this, InvalidAddress.prototype);
   }
 }
+
+export class LimitExceeded extends ExpectedError {
+  constructor(limit: number, message?: string) {
+    super(-32005, message || `query returned more than ${limit} results`);
+    Object.setPrototypeOf(this, InvalidAddress.prototype);
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -51,8 +51,8 @@ export class Method extends jayson.Method {
       .catch((error: Error) => {
         const metadata = {
           host: request?.headers?.host || undefined,
-          'cf-ray': request?.headers['cf-ray'] || undefined,
-          'cf-request-id': request?.headers['cf-request-id'] || undefined,
+          'cf-ray': request?.headers?.['cf-ray'] || undefined,
+          'cf-request-id': request?.headers?.['cf-request-id'] || undefined,
         };
         if (error instanceof ExpectedError) {
           return (callback as any)(

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -12,7 +12,10 @@ export const createServer = async({port = 0, attachAppToPort = true} = {}) => {
     HOME: os.homedir(),
   })
   const app = await createApp(
-    externalConfig,
+    {
+      ...externalConfig,
+      getLogsLimit: 5,
+    },
     logger,
     engine
   )

--- a/test/rpc_methods/eth_getFilterLogs.test.ts
+++ b/test/rpc_methods/eth_getFilterLogs.test.ts
@@ -231,7 +231,7 @@ describe('eth_getFilterLogs', () => {
     `)
   })
 
-  test('should return log object, without params', async () => {
+  test('should return error message, without params', async () => {
     const response = await request(app)
       .post('/')
       .send({
@@ -255,6 +255,6 @@ describe('eth_getFilterLogs', () => {
         params: [filterHash],
       })
 
-    expect(responseGetFilterLogs.body.error).toBeUndefined()
+    expect(responseGetFilterLogs.body.error.message).toBe('query returned more than 5 results')
   })
 })


### PR DESCRIPTION
Query:
```
{
    "jsonrpc": "2.0",
    "method": "eth_getLogs",
    "params": [
        {
            "fromBlock": 68851952,
            "toBlock": 69321936
        }
    ],
    "id": 2
}
```

Before
```
{
    "jsonrpc": "2.0",
    "id": 2,
    "result": [
        {
            "blockNumber": "0x420cbc7",
            "blockHash": "0x09ec018fd714d4ce3f7b19cdd08f95407cff31d66a3378ef2787298d69963315",
            "transactionIndex": "0x3",
            "transactionHash": "0x5c33fff8b0ab4d18f1894e2c2705c05c49fd2a87564b9e1e6a60049a8b00b824",
            "logIndex": "0x9",
            "address": "0x63da4db6ef4e7c62168ab03982399f9588fcd198",
            "topics": [
                "0x1c411e9a96e071241c2f21f7726b17ae89e3cab4c78be50e062b03a9fffbbad1"
            ],
            "data": "0x000000000000000000000000000000000000000798b47217ddd666b4c6297d84000000000000000000000000000000000000000000000062f18ceceab717d820",
            "removed": false
        },
        ...9999 events
```


After
```
{
    "jsonrpc": "2.0",
    "id": 2,
    "error": {
        "code": -32005,
        "message": "query returned more than 10000 results",
        "data": {
            "host": "localhost:8545",
            "request_body": {
                "jsonrpc": "2.0",
                "method": "eth_getLogs",
                "params": [
                    {
                        "fromBlock": 68851952,
                        "toBlock": 69321936
                    }
                ],
                "id": 2
            }
        }
    }
}
```

Same for `eth_getFilterLogs`, `eth_getFilterChanges`