### PR TITLE
Support text/plain format in body of request

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -13,6 +13,7 @@ export async function createApp(config, logger, engine) {
     app.use(middleware.setRequestID());
     app.use(middleware.blacklistIPs());
     app.use(bodyParser.json({ type: 'application/json' }));
+    app.use(bodyParser.text({ type: 'text/plain' }));
     app.use(middleware.logger(logger));
     app.use(cors()); // Access-Control-Allow-Origin: *
     app.get('/health', (req, res) => {
@@ -149,7 +150,7 @@ function rpcMiddleware(server) {
         if ((req.method || '') != 'POST') {
             return error(405, { Allow: 'POST' });
         }
-        if (!RegExp('application/json', 'i').test((req || { headers: {} }).headers['content-type'] || '')) {
+        if (!RegExp('application/json|text/plain', 'i').test((req || { headers: {} }).headers['content-type'] || '')) {
             return error(415);
         }
         const findRawTx = (element) => element.method == 'eth_sendRawTransaction';

--- a/src/app.ts
+++ b/src/app.ts
@@ -34,6 +34,7 @@ export async function createApp(
   app.use(middleware.setRequestID());
   app.use(middleware.blacklistIPs());
   app.use(bodyParser.json({ type: 'application/json' }));
+  app.use(bodyParser.text({ type: 'text/plain' }));
   app.use(middleware.logger(logger));
   app.use(cors()); // Access-Control-Allow-Origin: *
   app.get('/health', (req, res) => {
@@ -240,7 +241,7 @@ function rpcMiddleware(server: jayson.Server): any {
     }
 
     if (
-      !RegExp('application/json', 'i').test(
+      !RegExp('application/json|text/plain', 'i').test(
         (req || { headers: {} }).headers['content-type'] || ''
       )
     ) {


### PR DESCRIPTION
In ethers v6 they use `text/plain` for content type of request
https://github.com/ethers-io/ethers.js/blob/v6/src.ts/utils/fetch.ts#L221

### Reproduce
```
import { ethers } from 'ethers'

(async () => {
  const provider = new ethers.JsonRpcProvider(env)
  const block = await provider.getBlock('latest')
  console.log('block', block)
})();
```

### This PR
```
[~/dev/aurora/raw]$ node ethers_v6_aurora_mainnet_json_rpc.js                                                                                                                                      
body {"id":1,"method":"eth_chainId","params":[],"jsonrpc":"2.0"}
typeof (body) string
body [{"method":"eth_chainId","params":[],"id":2,"jsonrpc":"2.0"},{"method":"eth_getBlockByNumber","params":["latest",false],"id":3,"jsonrpc":"2.0"}]
typeof (body) string
block Block {
  provider: JsonRpcProvider {},
  number: 37157807,
  hash: '0x1e0d672829be2dea007905f7a4bdd6dd57a10563ec93215d62093b2ae3557aba',
  timestamp: 1620821235,
  parentHash: '0xfb3eb59c6ed78043a7cd948bba13e4efc35025e5aa1e8fa483b19fd7b6682c47',
  nonce: '0x0000000000000000',
  difficulty: 0n,
  gasLimit: 9007199254740991n,
  gasUsed: 0n,
  miner: '0x0000000000000000000000000000000000000000',
  extraData: '0x',
  baseFeePerGas: null
}
```

### https://mainnet.aurora.dev

```
[~/dev/aurora/raw]$ node ethers_v6_aurora_mainnet_json_rpc.js                                                                                                                                     
body {"id":1,"method":"eth_chainId","params":[],"jsonrpc":"2.0"}
typeof (body) string
body [{"method":"eth_chainId","params":[],"id":2,"jsonrpc":"2.0"},{"method":"eth_getBlockByNumber","params":["latest",false],"id":3,"jsonrpc":"2.0"}]
typeof (body) string
file:///Users/pavel/dev/aurora/raw/node_modules/.pnpm/ethers@6.0.0-beta-exports.10/node_modules/ethers/lib.esm/utils/errors.js:116
            error = new Error(message);
                    ^

Error: server response 400 Bad Request (request={  }, response={  }, error=null, code=SERVER_ERROR, version=6.0.0-beta-exports.10)
    at makeError (file:///Users/pavel/dev/aurora/raw/node_modules/.pnpm/ethers@6.0.0-beta-exports.10/node_modules/ethers/lib.esm/utils/errors.js:116:21)
    at assert (file:///Users/pavel/dev/aurora/raw/node_modules/.pnpm/ethers@6.0.0-beta-exports.10/node_modules/ethers/lib.esm/utils/errors.js:132:15)
    at FetchResponse.assertOk (file:///Users/pavel/dev/aurora/raw/node_modules/.pnpm/ethers@6.0.0-beta-exports.10/node_modules/ethers/lib.esm/utils/fetch.js:772:9)
    at JsonRpcProvider._send (file:///Users/pavel/dev/aurora/raw/node_modules/.pnpm/ethers@6.0.0-beta-exports.10/node_modules/ethers/lib.esm/providers/provider-jsonrpc.js:815:18)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async JsonRpcProvider._detectNetwork (file:///Users/pavel/dev/aurora/raw/node_modules/.pnpm/ethers@6.0.0-beta-exports.10/node_modules/ethers/lib.esm/providers/provider-jsonrpc.js:359:23)
    at async JsonRpcProvider.getNetwork (file:///Users/pavel/dev/aurora/raw/node_modules/.pnpm/ethers@6.0.0-beta-exports.10/node_modules/ethers/lib.esm/providers/abstract-provider.js:440:21)
    at async Promise.all (index 0)
    at async resolveProperties (file:///Users/pavel/dev/aurora/raw/node_modules/.pnpm/ethers@6.0.0-beta-exports.10/node_modules/ethers/lib.esm/utils/properties.js:33:21)
    at async JsonRpcProvider.getBlock (file:///Users/pavel/dev/aurora/raw/node_modules/.pnpm/ethers@6.0.0-beta-exports.10/node_modules/ethers/lib.esm/providers/abstract-provider.js:630:37) {
  code: 'SERVER_ERROR',
  request: FetchRequest {},
  response: FetchResponse {},
  error: undefined
}
```
